### PR TITLE
Optimized configuration for dns resolving, migrated include to include_tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ npm-debug.log
 *.sublime-*
 *nbactions*.xml
 .temp/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -26,14 +26,9 @@ The CQ-Action to use.
 
 The CQ-Handle to use.
 
-        aem_dispatcher_flush_resolve: false
+        # aem_dispatcher_flush_resolve_ip: 127.0.0.1
 
-Controls if the `--resolve` argument will be added to the `curl` command line.
-Use together with `aem_dispatcher_flush_resolve_ip` to override DNS.
-
-        aem_dispatcher_flush_resolve_ip: 127.0.0.1
-
-The IP of the flush target(s). Use together with `aem_dispatcher_flush_resolve: true` in order to override DNS.
+Overrides the dns resolving by using the `--resolve` curl argument for flush operations.
 
         aem_dispatcher_flush_location: /dispatcher/invalidate.cache
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,16 +1,20 @@
-# list of flush targets
+# List of flush targets
 aem_dispatcher_flush_targets: []
-# controls the --no-proxy curl argument
+
+# Controls the --no-proxy curl argument
 aem_dispatcher_flush_noproxy: false
-# the cq action to execute
+
+# The cq action to execute
 aem_dispatcher_flush_cq_action: Delete
-# the handle of the cq action
+
+# The handle of the cq action
 aem_dispatcher_flush_cq_handle: /
-# controls the usage of the --resolve curl argument
-aem_dispatcher_flush_resolve: false
-# the ip adress the host should be resolved to
-aem_dispatcher_flush_resolve_ip: 127.0.0.1
-# the location of the dispatcher flush
+
+# When set the hostname will be resolved to the configured IP via --resolve
+# aem_dispatcher_flush_resolve_ip: 127.0.0.1
+
+# The location of the dispatcher flush
 aem_dispatcher_flush_location: /dispatcher/invalidate.cache
-# allow insecure connection
+
+# Allow insecure connections
 aem_dispatcher_flush_insecure: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,3 @@
 # handler for dispatcher flush
 - name: flush dispatcher
-  include: flush_targets.yml
+  include_tasks: flush_targets.yml

--- a/tasks/flush_target.yml
+++ b/tasks/flush_target.yml
@@ -14,7 +14,7 @@
 - name: "{{ item }} : Add '--resolve'"
   set_fact:
     _flush_resolve_argument: '--resolve "{{ _flush_target.hostname }}:{{ _flush_target.scheme_port }}:{{ aem_dispatcher_flush_resolve_ip }}"'
-  when: aem_dispatcher_flush_resolve
+  when: aem_dispatcher_flush_resolve_ip is defined
 
   #- name: Add --noproxy option when defined
 - name: "{{ item }} : Add '--noproxy'"

--- a/tasks/flush_targets.yml
+++ b/tasks/flush_targets.yml
@@ -1,4 +1,4 @@
   # executes flush for every defined flush target
-- include: flush_target.yml
+- include_tasks: flush_target.yml
   with_items: "{{ aem_dispatcher_flush_targets }}"
   when: aem_dispatcher_flush_targets|length > 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,4 @@
-  # debug echo when not flush targets provided
-- debug:
-    msg: "No flush targets provided in var 'aem_dispatcher_flush_targets'"
-  when: aem_dispatcher_flush_targets|length == 0
-
   # executes flush for every defined flush target
 - name: "Flush dispatcher caches"
-  include: flush_targets.yml
+  include_tasks: flush_targets.yml
   when: aem_dispatcher_flush_targets|length > 0


### PR DESCRIPTION
* Removed the obvious `aem_dispatcher_flush_resolve` parameter since the behavior can be bound to the existance of the `aem_dispatcher_flush_resolve_ip`.

* Migrated deprecated `include` to `include_tasks`